### PR TITLE
Reduce app's database hits, and refactor

### DIFF
--- a/moxie/app.py
+++ b/moxie/app.py
@@ -37,11 +37,36 @@ docker = Docker()
 
 
 @asyncio.coroutine
-def table_to_tuple(jobs_runs, limit=10):
-    job_keys = [key for key in Job.__dict__.keys() if not key.startswith("__")]
+def get_job_runs(where_clause=Job.id.isnot(None), limit=10):
+    '''
+    Return Jobs and their most recent Runs. The default is to return
+    all Jobs, but this can be subset by passing a SQLAlchemy-compatible
+    clause for a `where`.
 
+    The format that goes to the view template will look like this:
+    [
+        Job_one: [Run_one, Run_two, ...],
+        Job_two: [Run_one, Run_two, ...],
+        ...
+    ]
+    '''
+
+    # Get a table where each row is a Job and one of its Runs
+    engine = yield from aiopg.sa.create_engine(DATABASE_URL)
+    with (yield from engine) as conn:
+        jobs_runs = yield from conn.execute(select(
+            [Job.__table__, Run.__table__],
+            use_labels=True
+        ).select_from(join(
+            Job.__table__,
+            Run.__table__,
+            Job.id == Run.job_id
+        )).where(where_clause).order_by(Run.id.desc()))
+
+    job_keys = [key for key in Job.__dict__.keys() if not key.startswith("__")]
     jobs = {}
     for job_run in jobs_runs:
+        # Create a phony Job-ish object for use in the view template
         job = {}
         for key in job_keys:
             job[key] = getattr(job_run, "job_" + key, None)
@@ -50,6 +75,7 @@ def table_to_tuple(jobs_runs, limit=10):
             jobs[job_run.job_id] = [job, []]
         jobs[job_run.job_id][1].append(job_run)
 
+    # Only pass the most recent _limit_ Runs to the view
     return [(job, runs[:limit]) for (job, runs) in jobs.values()]
 
 
@@ -72,21 +98,9 @@ def overview(request):
 
 @app.register("^jobs/$")
 def jobs(request):
-    engine = yield from aiopg.sa.create_engine(DATABASE_URL)
-    with (yield from engine) as conn:
-
-        res = yield from conn.execute(select(
-            [Job.__table__, Run.__table__],
-            use_labels=True
-        ).select_from(join(
-            Job.__table__,
-            Run.__table__,
-            Job.id == Run.job_id
-        )).order_by(Run.id.desc()))
-
-        return request.render('jobs.html', {
-            "jobs": (yield from table_to_tuple(res)),
-        })
+    return request.render('jobs.html', {
+        "jobs": (yield from get_job_runs()),
+    })
 
 
 @app.register("^run/(?P<key>.*)/$")
@@ -121,38 +135,18 @@ def maintainer(request, id):
         )
         maintainer = yield from maintainers.first()
 
-        jobs = yield from conn.execute(select(
-            [Job.__table__, Run.__table__],
-            use_labels=True
-        ).select_from(join(
-            Job.__table__,
-            Run.__table__,
-            Job.id == Run.job_id
-        )).where(Job.maintainer_id == id).order_by(Run.id.desc()))
-
-        return request.render('maintainer.html', {
-            "maintainer": maintainer,
-            "jobs": (yield from table_to_tuple(jobs)),
-        })
+    return request.render('maintainer.html', {
+        "maintainer": maintainer,
+        "jobs": (yield from get_job_runs(Job.maintainer_id.__eq__(int(id)))),
+    })
 
 
 @app.register("^tag/(?P<id>.*)/$")
 def tag(request, id):
-    engine = yield from aiopg.sa.create_engine(DATABASE_URL)
-    with (yield from engine) as conn:
-        jobs = yield from conn.execute(select(
-            [Job.__table__, Run.__table__],
-            use_labels=True
-        ).select_from(join(
-            Job.__table__,
-            Run.__table__,
-            Job.id == Run.job_id
-        )).where(Job.tags.contains([id])).order_by(Run.id.desc()))
-
-        return request.render('tag.html', {
-            "tag": id,
-            "jobs": (yield from table_to_tuple(jobs)),
-        })
+    return request.render('tag.html', {
+        "tag": id,
+        "jobs": (yield from get_job_runs(Job.tags.contains([id]))),
+    })
 
 
 @app.register("^job/(?P<name>.*)/$")
@@ -215,18 +209,6 @@ def container(request, name):
 
 @app.register("^cast/$")
 def cast(request):
-    engine = yield from aiopg.sa.create_engine(DATABASE_URL)
-    with (yield from engine) as conn:
-        runs = yield from conn.execute(select(
-            [Run.__table__, Job.__table__,],
-            use_labels=True
-        ).select_from(join(
-            Run.__table__,
-            Job.__table__,
-            Run.job_id == Job.id
-        )).order_by(desc(Run.start_time)).limit(10))
-        runs = list(runs)
-
     return request.render('cast.html', {
-        "runs": runs
+        "runs": (yield from get_job_runs())
     })

--- a/moxie/app.py
+++ b/moxie/app.py
@@ -76,7 +76,7 @@ def get_job_runs(where_clause=Job.id.isnot(None), limit=10):
         jobs[job_run.job_id][1].append(job_run)
 
     # Only pass the most recent _limit_ Runs to the view
-    return [(job, runs[:limit]) for (job, runs) in jobs.values()]
+    return [(job, runs[:limit]) for (job, runs) in sorted(jobs.values(), key=lambda k: k[0]['name'])]
 
 
 @app.websocket("^websocket/stream/(?P<name>.*)/$")


### PR DESCRIPTION
This turns each view into just one or two database queries, instead of one per `Job`. Hopefully, this'll speed up Moxie in production, and permit us to move all of our Open States jobs there.
:us: :fireworks:

@paultag, let me know what changes I need to make to get this up to snuff! First time using `asyncio`, so let me know if I've broken any rules or best-practices.