### PR TITLE
Improve speed an remove SQL injection surface

### DIFF
--- a/moxie/app.py
+++ b/moxie/app.py
@@ -62,7 +62,6 @@ def get_job_runs(where_clause=text('TRUE'), limit=10):
             Job.tags AS job_tags,
             Run.id AS run_id,
             Run.failed AS run_failed,
-            Run.log AS run_log,
             Run.start_time AS run_start_time,
             Run.end_time AS run_end_time
         FROM Job
@@ -191,9 +190,11 @@ def job(request, name):
         )).where(Job.name == name).limit(1))
         job = yield from jobs.first()
 
-        runs = yield from conn.execute(select([Run.__table__]).where(
-            Run.job_id == job.job_id
-        ).order_by(Run.id.desc()))
+        runs = yield from conn.execute(
+            select([Run.id, Run.failed, Run.start_time, Run.end_time]).
+            where(Run.job_id == job.job_id).
+            order_by(Run.id.desc())
+        )
 
         return request.render('job.html', {
             "job": job,


### PR DESCRIPTION
Rejiggered the code so that `Job` filtering doesn't happen in raw SQL, and so we're now safe on that front.

Also, realized that the views that use the `Job`–`Run` lists don't need the `Run.log`s, which in some cases are enormous and were the main reason the views were so slow. Removed `Run.log`s from every query I could, and now performance should be better.