### PR TITLE
Use more aggressive deb-src entry generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ MAINTAINER  Paul R. Tagliamonte <paultag@debian.org>
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN echo "deb-src http://http.debian.net/debian/ jessie main" > /etc/apt/sources.list.d/moxie.list
+# add deb-src entries
+RUN find /etc/apt/sources.list* -type f -exec sed -i 'p; s/^deb /deb-src /' '{}' +
+
 RUN apt-get update && apt-get install -y \
     python3.4 \
     python3-pip \


### PR DESCRIPTION
This does have the _potential_ for adding `deb-src` entries more than once, but APT appropriately de-dupes them, so the end result is harmless.

(This is my best guess for why the builds were failing so badly.)