### PR TITLE
Avoid build breakage by switching Dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,17 @@ RUN apt-get update && apt-get install -y \
     node-uglify \
     node-less \
     coffeescript \
-    locales-all
+    locales-all \
+    libssl-dev \
+    libffi-dev \
+    python-dev
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 ENV PYTHONIOENCODING utf-8
 
-RUN apt-get update && apt-get build-dep -y python3-psycopg2 python3-cryptography
+RUN apt-get update && apt-get build-dep -y python3-psycopg2
 
 RUN mkdir -p /opt/pault.ag/
 ADD . /opt/pault.ag/moxie/


### PR DESCRIPTION
Last couple of builds have failed, seems like something to do with the Debian `python3-cryptography` package not installing all the necessary libraries. I swapped out using [installation directions from `cryptography`'s docs]
(https://cryptography.io/en/latest/installation/#building-cryptography-on-linux), and am no longer getting `Dockerfile` build failures locally.